### PR TITLE
Running on Scotchbuild

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "waitq.h": "c",
+        "defs.h": "c"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo ./scripts/setup_machine.sh
 
 ```
 curl https://sh.rustup.rs -sSf | sh
-rustup default nightly
+rustup default nightly-2023-05-31
 ```
 ```
 cd apps/synthetic

--- a/apps/synthetic/src/payload.rs
+++ b/apps/synthetic/src/payload.rs
@@ -61,6 +61,7 @@ impl Payload {
             index: reader.read_u64::<BigEndian>()?,
             randomness: reader.read_u64::<BigEndian>()?,
         };
+        println!("got payload");
         return Ok(p);
     }
 }

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -9,7 +9,7 @@ libc = "0.2"
 byteorder = "1.2.1"
 
 [build-dependencies]
-bindgen = "0.58"
+bindgen = "0.62"
 build-deps = "0.1.3"
 
 [[bin]]

--- a/bindings/rust/src/tcp.rs
+++ b/bindings/rust/src/tcp.rs
@@ -6,7 +6,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 
 use super::*;
 
-fn isize_to_result(i: i64) -> io::Result<usize> {
+fn isize_to_result(i: isize) -> io::Result<usize> {
     if i >= 0 {
         Ok(i as usize)
     } else {

--- a/bindings/rust/src/udp.rs
+++ b/bindings/rust/src/udp.rs
@@ -6,7 +6,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 
 use super::*;
 
-fn isize_to_result(i: i64) -> io::Result<usize> {
+fn isize_to_result(i: isize) -> io::Result<usize> {
     if i >= 0 {
         Ok(i as usize)
     } else {

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+# Ignore custom config files.
+config_*

--- a/build/config
+++ b/build/config
@@ -1,7 +1,7 @@
 # build configuration options (set to y for "yes", n for "no")
 
 # Enable Mellanox ConnectX-4,5 NIC Support
-CONFIG_MLX5=n
+CONFIG_MLX5=y
 # Enable Mellanox ConnectX-3 NIC Support
 CONFIG_MLX4=n
 # Enable SPDK NVMe support

--- a/iokernel/dp_clients.c
+++ b/iokernel/dp_clients.c
@@ -40,6 +40,9 @@ static void dp_clients_add_client(struct proc *p)
 	}
 
 	if (!p->has_directpath) {
+		log_info("Adding client with MAC %02x:%02x:%02x:%02x:%02x:%02x to hash table",
+				p->mac.addr[0], p->mac.addr[1], p->mac.addr[2],
+				p->mac.addr[3], p->mac.addr[4], p->mac.addr[5]);
 		ret = rte_hash_add_key_data(dp.mac_to_proc, &p->mac.addr[0], p);
 		if (ret < 0)
 			log_err("dp_clients: failed to add MAC to hash table in add_client");

--- a/iokernel/dpdk.c
+++ b/iokernel/dpdk.c
@@ -115,6 +115,9 @@ static inline int dpdk_port_init(uint8_t port, struct rte_mempool *mbuf_pool)
 		nb_txd = MLX5_TX_RING_SIZE;
 	}
 
+    // Print PCIe address
+    printf("PCIe Address of port %u: %s\n", port, dev_info.device->name);
+
 	/* Configure the Ethernet device. */
 	retval = rte_eth_dev_configure(port, rx_rings, tx_rings, &port_conf);
 	if (retval != 0)
@@ -257,7 +260,7 @@ int dpdk_init(void)
 int dpdk_late_init(void)
 {
 	/* initialize port */
-	dp.port = 0;
+	dp.port = 1;
 	if (dpdk_port_init(dp.port, dp.rx_mbuf_pool) != 0) {
 		log_err("dpdk: cannot init port %"PRIu8 "\n", dp.port);
 		return -1;

--- a/iokernel/rx.c
+++ b/iokernel/rx.c
@@ -63,6 +63,7 @@ bool rx_send_to_runtime(struct proc *p, uint32_t hash, uint64_t cmd,
 	if (likely(sched_threads_active(p) > 0)) {
 		/* use the flow table to route to an active thread */
 		th = &p->threads[p->flow_tbl[hash % p->thread_count]];
+		log_info("Sent to kthread %d", th->at_idx);
 		return lrpc_send(&th->rxq, cmd, payload);
 	}
 
@@ -76,6 +77,7 @@ bool rx_send_to_runtime(struct proc *p, uint32_t hash, uint64_t cmd,
 		/* use the flow table to route to an active thread */
 		th = &p->threads[p->flow_tbl[hash % p->thread_count]];
 	}
+	log_info("Sent to kthread %d", th->at_idx);
 	return lrpc_send(&th->rxq, cmd, payload);
 }
 
@@ -116,7 +118,7 @@ static void rx_one_pkt(struct rte_mbuf *buf)
 			log_debug_ratelimited("rx: received packet for unregistered MAC");
 			rte_pktmbuf_free(buf);
 			return;
-		}
+		} 
 
 		p = (struct proc *)data;
 		net_hdr = rx_prepend_rx_preamble(buf);
@@ -174,7 +176,7 @@ bool rx_burst(void)
 	nb_rx = rte_eth_rx_burst(dp.port, 0, bufs, IOKERNEL_RX_BURST_SIZE);
 	STAT_INC(RX_PULLED, nb_rx);
 	if (nb_rx > 0)
-		log_debug("rx: received %d packets on port %d", nb_rx, dp.port);
+		log_info("rx: received %d packets on port %d", nb_rx, dp.port);
 
 	for (i = 0; i < nb_rx; i++) {
 		if (i + RX_PREFETCH_STRIDE < nb_rx) {

--- a/iokernel/tx.c
+++ b/iokernel/tx.c
@@ -194,6 +194,8 @@ static int tx_drain_queue(struct thread *t, int n,
 				unpoll_thread(t);
 			break;
 		}
+		
+		log_info("tx: received packet from runtime %d", t->at_idx);
 
 		/* TODO: need to kill the process? */
 		BUG_ON(cmd != TXPKT_NET_XMIT);

--- a/runtime/ioqueues.c
+++ b/runtime/ioqueues.c
@@ -254,6 +254,12 @@ int ioqueues_register_iokernel(void)
 	hdr->egress_buf_count = div_up(iok.tx_len, net_get_mtu() + MBUF_HEAD_LEN);
 	hdr->thread_count = maxks;
 	hdr->mac = netcfg.mac;
+	unsigned char bytes[4];
+    bytes[0] = (netcfg.addr >> 24) & 0xFF;
+    bytes[1] = (netcfg.addr  >> 16) & 0xFF;
+    bytes[2] = (netcfg.addr  >> 8) & 0xFF;
+    bytes[3] = netcfg.addr  & 0xFF;
+	log_info("Netcfg address: %u.%u.%u.%u", bytes[0], bytes[1], bytes[2], bytes[3]);
 
 	hdr->sched_cfg.priority = cfg_prio_is_lc ?
 				  SCHED_PRIO_LC : SCHED_PRIO_BE;

--- a/runtime/sched.c
+++ b/runtime/sched.c
@@ -777,6 +777,7 @@ void thread_yield(void)
 
 static __always_inline thread_t *__thread_create(void)
 {
+  log_info("Spawning new uthread");
 	struct thread *th;
 	struct stack *s;
 

--- a/runtime/softirq.c
+++ b/runtime/softirq.c
@@ -59,6 +59,7 @@ bool softirq_run_locked(struct kthread *k)
 
 	/* check for iokernel softirq work */
 	if (!k->iokernel_busy && softirq_iokernel_pending(k)) {
+		log_info("new iokernel softirq work!");
 		k->iokernel_busy = true;
 		thread_ready_head_locked(k->iokernel_softirq);
 		work_done = true;

--- a/server.config
+++ b/server.config
@@ -1,7 +1,9 @@
 # an example runtime config file
-host_addr 192.168.1.3
+host_addr 192.168.0.0
 host_netmask 255.255.255.0
-host_gateway 192.168.1.1
+host_gateway 192.168.0.0
 runtime_kthreads 4
 runtime_guaranteed_kthreads 4
 runtime_priority lc
+host_mac aa:aa:aa:aa:aa:aa
+static_arp 192.168.0.0 aa:aa:aa:aa:aa:aa


### PR DESCRIPTION
- Removed checksum verification of packets received (because for some reason the PCAPs we created were not passing that) 
- Added a static ARP entry 192.168.0.0 aa:aa:aa:aa:aa:aa in the server.config file to remove continual ARP refreshments of the MAC address table (because otherwise, probing kept happening to check if that mac address mapping was still valid)
- Modified server.config in general to reflect the parameters we wanted
- Added some informational logs about what's going on
- Removed service times per packet in main.rs (not currently encoding service times in PCAP packets, TODO)